### PR TITLE
Relaxed accept header handling

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 var contentType = require('content-type');
 var createError = require('http-errors');
 
+var acceptRE = /(.+".+"[^,]*|[^,]+)/;
+
 module.exports = function (supportedExt) {
   supportedExt = supportedExt || [];
   if (!Array.isArray(supportedExt)) {
@@ -48,10 +50,29 @@ module.exports = function (supportedExt) {
 
     try {
       var accept = req.get('accept');
-      if (!accept) {
-        return next(createError(406));
+      if (accept) {
+        var matches = accept.match(acceptRE);
+        matches.shift();
+        var errs = [];
+        var count = 0;
+        matches.forEach(function (val) {
+            if (val.indexOf('application/vnd.api+json') !== -1) {
+              count++;
+              try {
+                setCT(resCT, val);
+              }
+              catch (e) {
+                errs.push(e);
+              }
+            }
+          });
+
+        // If all instances of the JSON API accept header are modified, throw a
+        // 406 error.
+        if (count && count === errs.length) {
+          throw createError(406);
+        }
       }
-      setCT(resCT, accept);
 
       var reqCT = req.get('content-type');
       if (reqCT) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-headers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provide a middleware to validate JSON API headers on a request",
   "main": "lib/headers.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -25,13 +25,13 @@ module.exports = {
 
     test.done();
   },
-  emptyExtensions: function (test) {
+  emptyHeaders: function (test) {
     test.expect(1);
     var tHeaders = headers();
 
     testHeaders(
       tHeaders,
-      'application/vnd.api+json',
+      undefined,
       undefined,
       function (key, val) {
         test.equal(val, 'application/vnd.api+json');
@@ -39,18 +39,30 @@ module.exports = {
       test.done
     );
   },
-  invalidParameters: function (test) {
+  undefinedAccept: function (test) {
     test.expect(1);
     var tHeaders = headers();
     testHeaders(
       tHeaders,
-      'application/vnd.api+json; charset=test',
+      '*/*; charset=test',
       undefined,
-      test.done,
-      function (err) {
-        test.equal(err.status, 415, 'Unexpected error code.');
-        test.done();
-      }
+      function (key, val) {
+        test.equal(val, 'application/vnd.api+json');
+      },
+      test.done
+    );
+  },
+  mixexValidAccept: function (test) {
+    test.expect(1);
+    var tHeaders = headers();
+    testHeaders(
+      tHeaders,
+      'application/vnd.api+json,application/vnd.api+json; charset=test',
+      undefined,
+      function (key, val) {
+        test.equal(val, 'application/vnd.api+json');
+      },
+      test.done
     );
   },
   invalidAccept: function (test) {
@@ -58,11 +70,25 @@ module.exports = {
     var tHeaders = headers();
     testHeaders(
       tHeaders,
+      'application/vnd.api+json; charset=test',
+      undefined,
+      test.done,
+      function (err) {
+        test.equal(err.status, 406, 'Unexpected error code.');
+        test.done();
+      }
+    );
+  },
+  invalidParameters: function (test) {
+    test.expect(1);
+    var tHeaders = headers();
+    testHeaders(
+      tHeaders,
       undefined,
       'application/vnd.api+json; charset=test',
       test.done,
       function (err) {
-        test.equal(err.status, 406, 'Unexpected error code.');
+        test.equal(err.status, 415, 'Unexpected error code.');
         test.done();
       }
     );


### PR DESCRIPTION
The JSON API spec states that a 406 should only be thrown if every instance of the JSON API header in the `Accept` header is modified. This means that the absence of the JSON API header should not generate an error.