### PR TITLE
Must call function exported by jsonapi-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ JSON API based systems. In additon to basic [content negotiation](http://jsonapi
 
 ```javascript
 // Without extension support.
-app.use(require('jsonapi-headers'));
+app.use(require('jsonapi-headers')());
 
 // OR With extension support.
 app.use(require('jsonapi-headers')(['batch', 'jsonpatch']));


### PR DESCRIPTION
This PR introduces a minor tweak to this project's documentation. This tweak instructs users to call the return value of `require('jsonapi-header')` even when no extensions are being passed in. Failing to do this will cause Express to throw a `Supported extensions must be an array.` error.